### PR TITLE
python-ipy: fix SRC_URI

### DIFF
--- a/recipes-devtools/python/python-ipy_0.83.bb
+++ b/recipes-devtools/python/python-ipy_0.83.bb
@@ -9,7 +9,7 @@ DEPENDS = "python"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://COPYING;md5=ebc0028ff5cdaf7796604875027dcd55"
 
-SRC_URI = "http://pypi.python.org/packages/source/I/IPy/IPy-${PV}.tar.gz"
+SRC_URI = "https://pypi.python.org/packages/source/I/IPy/IPy-${PV}.tar.gz"
 
 SRC_URI[md5sum] = "7b8c6eb4111b15aea31b67108e769712"
 SRC_URI[sha256sum] = "61da5a532b159b387176f6eabf11946e7458b6df8fb8b91ff1d345ca7a6edab8"


### PR DESCRIPTION
Otherwise the build fails with:

HTTP request sent, awaiting response... 403 SSL is required
2017-12-03 22:16:33 ERROR 403: SSL is required.

Signed-off-by: Javier Viguera <javier.viguera@digi.com>